### PR TITLE
HOCS-2577 - Downgrade schema to draft V4

### DIFF
--- a/src/main/resources/cmsSchema.json
+++ b/src/main/resources/cmsSchema.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "http://json-schema.org/draft/2019-09/schema#",
+  "$schema": "http://json-schema.org/draft-04/schema#",
   "title": "UKVI Complaint",
   "description": "The JSON sent between the HO UKVI complaints service and DECS",
   "definitions": {

--- a/src/test/java/uk/gov/digital/ho/hocs/correspondence/JSONValidate.java
+++ b/src/test/java/uk/gov/digital/ho/hocs/correspondence/JSONValidate.java
@@ -20,7 +20,7 @@ import static org.junit.Assert.fail;
 public class JSONValidate {
 
     private final ObjectMapper objectMapper = new ObjectMapper();
-    private final JsonSchemaFactory schemaFactory = JsonSchemaFactory.getInstance(SpecVersion.VersionFlag.V201909);
+    private final JsonSchemaFactory schemaFactory = JsonSchemaFactory.getInstance(SpecVersion.VersionFlag.V4);
 
     @Test
     public void existing() throws Exception {


### PR DESCRIPTION
Tiny change to downgrade schema draft version. Needed because V4 is the default that camel uses, and its easier to change this than implement something specific.