### PR TITLE
HOCS-2578 - Restructure to similar pattern for each complaint type

### DIFF
--- a/src/main/resources/cmsSchema.json
+++ b/src/main/resources/cmsSchema.json
@@ -277,10 +277,7 @@
       "type": "object",
       "required": [
         "experienceType",
-        "location",
-        "reference",
-        "reporterDetails",
-        "complaintDetails"
+        "location"
       ],
       "properties": {
         "experienceType": {
@@ -301,23 +298,6 @@
               "$ref": "#/definitions/UkVcasCentre"
             }
           ]
-        },
-        "reference": {
-          "$ref": "#/definitions/Reference"
-        },
-        "reporterDetails": {
-          "$ref": "#/definitions/ReporterDetails"
-        },
-        "complaintDetails": {
-          "type": "object",
-          "required": [
-            "complaintText"
-          ],
-          "properties": {
-            "complaintText": {
-              "$ref": "#/definitions/ComplaintDetailsText"
-            }
-          }
         }
       }
     },
@@ -325,10 +305,7 @@
       "type": "object",
       "required": [
         "experienceType",
-        "callDetails",
-        "reference",
-        "reporterDetails",
-        "complaintDetails"
+        "callDetails"
       ],
       "properties": {
         "experienceType": {
@@ -361,33 +338,13 @@
               "type": "string"
             }
           }
-        },
-        "reference": {
-          "$ref": "#/definitions/Reference"
-        },
-        "reporterDetails": {
-          "$ref": "#/definitions/ReporterDetails"
-        },
-        "complaintDetails": {
-          "type": "object",
-          "required": [
-            "complaintText"
-          ],
-          "properties": {
-            "complaintText": {
-              "$ref": "#/definitions/ComplaintDetailsText"
-            }
-          }
         }
       }
     },
     "LetterEmailExperience": {
       "type": "object",
       "required": [
-        "experienceType",
-        "reference",
-        "reporterDetails",
-        "complaintDetails"
+        "experienceType"
       ],
       "properties": {
         "experienceType": {
@@ -395,23 +352,6 @@
           "enum": [
             "LETTER_OR_EMAIL"
           ]
-        },
-        "reference": {
-          "$ref": "#/definitions/Reference"
-        },
-        "reporterDetails": {
-          "$ref": "#/definitions/ReporterDetails"
-        },
-        "complaintDetails": {
-          "type": "object",
-          "required": [
-            "complaintText"
-          ],
-          "properties": {
-            "complaintText": {
-              "$ref": "#/definitions/ComplaintDetailsText"
-            }
-          }
         }
       }
     },
@@ -429,9 +369,6 @@
           "enum": [
             "SUBMITTING_APPLICATION"
           ]
-        },
-        "applicationLocation": {
-          "$ref": "#/definitions/ApplicationLocation"
         },
         "reference": {
           "$ref": "#/definitions/Reference"
@@ -456,6 +393,9 @@
                 "GUIDANCE",
                 "SOMETHING_ELSE"
               ]
+            },
+            "applicationLocation": {
+              "$ref": "#/definitions/ApplicationLocation"
             }
           }
         }
@@ -590,7 +530,8 @@
       "type": "object",
       "required": [
         "complaintType",
-        "experience"
+        "complaintDetails",
+        "reporterDetails"
       ],
       "properties": {
         "complaintType": {
@@ -599,18 +540,33 @@
             "POOR_STAFF_BEHAVIOUR"
           ]
         },
-        "experience": {
-          "oneOf": [
-            {
-              "$ref": "#/definitions/FaceToFaceExperience"
+        "reporterDetails": {
+          "$ref": "#/definitions/ReporterDetails"
+        },
+        "complaintDetails": {
+          "type": "object",
+          "required": [
+            "complaintText",
+            "experience"
+          ],
+          "properties": {
+            "complaintText": {
+              "$ref": "#/definitions/ComplaintDetailsText"
             },
-            {
-              "$ref": "#/definitions/PhoneExperience"
-            },
-            {
-              "$ref": "#/definitions/LetterEmailExperience"
+            "experience": {
+              "oneOf": [
+                {
+                  "$ref": "#/definitions/FaceToFaceExperience"
+                },
+                {
+                  "$ref": "#/definitions/PhoneExperience"
+                },
+                {
+                  "$ref": "#/definitions/LetterEmailExperience"
+                }
+              ]
             }
-          ]
+          }
         }
       }
     },
@@ -692,8 +648,7 @@
         "complaintType",
         "reference",
         "reporterDetails",
-        "complaintDetails",
-        "delayedWaitingFor"
+        "complaintDetails"
       ],
       "properties": {
         "complaintType": {
@@ -701,19 +656,6 @@
           "enum": [
             "DELAYS"
           ]
-        },
-        "delayedWaitingFor": {
-          "type": "string",
-          "enum": [
-            "APPLICATION_DELAY",
-            "RETURN_OF_DOCUMENTS"
-          ]
-        },
-        "applicationSubmittedWhen": {
-          "type": "string"
-        },
-        "applicationLocation": {
-          "$ref": "#/definitions/ApplicationLocation"
         },
         "documentReturnRequest": {
           "type": "string",
@@ -732,11 +674,25 @@
         "complaintDetails": {
           "type": "object",
           "required": [
-            "complaintText"
+            "complaintText",
+            "delayedWaitingFor"
           ],
           "properties": {
             "complaintText": {
               "$ref": "#/definitions/ComplaintDetailsText"
+            },
+            "delayedWaitingFor": {
+              "type": "string",
+              "enum": [
+                "APPLICATION_DELAY",
+                "RETURN_OF_DOCUMENTS"
+              ]
+            },
+            "applicationSubmittedWhen": {
+              "type": "string"
+            },
+            "applicationLocation": {
+              "$ref": "#/definitions/ApplicationLocation"
             }
           }
         }
@@ -748,24 +704,13 @@
         "complaintType",
         "reference",
         "reporterDetails",
-        "complaintDetails",
-        "decisionOutcome"
+        "complaintDetails"
       ],
       "properties": {
         "complaintType": {
           "type": "string",
           "enum": [
             "IMMIGRATION_DECISION"
-          ]
-        },
-        "applicationLocation": {
-          "$ref": "#/definitions/ApplicationLocation"
-        },
-        "decisionOutcome": {
-          "type": "string",
-          "enum": [
-            "NEGATIVE",
-            "POSITIVE"
           ]
         },
         "reference": {
@@ -777,11 +722,22 @@
         "complaintDetails": {
           "type": "object",
           "required": [
-            "complaintText"
+            "complaintText",
+            "decisionOutcome"
           ],
           "properties": {
             "complaintText": {
               "$ref": "#/definitions/ComplaintDetailsText"
+            },
+            "applicationLocation": {
+              "$ref": "#/definitions/ApplicationLocation"
+            },
+            "decisionOutcome": {
+              "type": "string",
+              "enum": [
+                "NEGATIVE",
+                "POSITIVE"
+              ]
             }
           }
         }
@@ -793,36 +749,13 @@
         "complaintType",
         "reference",
         "reporterDetails",
-        "complaintDetails",
-        "refundRequested"
+        "complaintDetails"
       ],
       "properties": {
         "complaintType": {
           "type": "string",
           "enum": [
             "REFUND"
-          ]
-        },
-        "applicationLocation": {
-          "$ref": "#/definitions/ApplicationLocation"
-        },
-        "refundRequested": {
-          "type": "string",
-          "enum": [
-            "YES",
-            "NO",
-            "NOT_YET"
-          ]
-        },
-        "refundType": {
-          "type": "string",
-          "enum": [
-            "STANDARD",
-            "PRIORITY",
-            "SUPER_PRIORITY",
-            "PREMIUM",
-            "IHS",
-            "EU_SETTLEMENT"
           ]
         },
         "reference": {
@@ -834,11 +767,34 @@
         "complaintDetails": {
           "type": "object",
           "required": [
-            "complaintText"
+            "complaintText",
+            "refundRequested"
           ],
           "properties": {
             "complaintText": {
               "$ref": "#/definitions/ComplaintDetailsText"
+            },
+            "applicationLocation": {
+              "$ref": "#/definitions/ApplicationLocation"
+            },
+            "refundRequested": {
+              "type": "string",
+              "enum": [
+                "YES",
+                "NO",
+                "NOT_YET"
+              ]
+            },
+            "refundType": {
+              "type": "string",
+              "enum": [
+                "STANDARD",
+                "PRIORITY",
+                "SUPER_PRIORITY",
+                "PREMIUM",
+                "IHS",
+                "EU_SETTLEMENT"
+              ]
             }
           }
         }

--- a/src/main/resources/cmsSchema.json
+++ b/src/main/resources/cmsSchema.json
@@ -9,6 +9,7 @@
         "country",
         "city"
       ],
+      "additionalProperties": false,
       "properties": {
         "country": {
           "type": "string"
@@ -23,6 +24,7 @@
       "required": [
         "city"
       ],
+      "additionalProperties": false,
       "properties": {
         "city": {
           "type": "string"
@@ -34,6 +36,7 @@
       "required": [
         "city"
       ],
+      "additionalProperties": false,
       "properties": {
         "city": {
           "type": "string"
@@ -50,6 +53,7 @@
         "agentType",
         "agentEmail"
       ],
+      "additionalProperties": false,
       "properties": {
         "agentName": {
           "type": "string"
@@ -78,6 +82,7 @@
         "applicantNationality",
         "applicantDob"
       ],
+      "additionalProperties": false,
       "properties": {
         "applicantName": {
           "type": "string"
@@ -100,6 +105,7 @@
         "applicantDob",
         "applicantEmail"
       ],
+      "additionalProperties": false,
       "properties": {
         "applicantType": {
           "type": "string",
@@ -132,6 +138,7 @@
         "applicantDetails",
         "agentDetails"
       ],
+      "additionalProperties": false,
       "properties": {
         "applicantType": {
           "type": "string",
@@ -177,6 +184,7 @@
         "referenceType",
         "reference"
       ],
+      "additionalProperties": false,
       "properties": {
         "referenceType": {
           "type": "string",
@@ -196,6 +204,7 @@
         "referenceType",
         "reference"
       ],
+      "additionalProperties": false,
       "properties": {
         "referenceType": {
           "type": "string",
@@ -215,6 +224,7 @@
         "referenceType",
         "reference"
       ],
+      "additionalProperties": false,
       "properties": {
         "referenceType": {
           "type": "string",
@@ -234,6 +244,7 @@
         "referenceType",
         "reference"
       ],
+      "additionalProperties": false,
       "properties": {
         "referenceType": {
           "type": "string",
@@ -279,6 +290,7 @@
         "experienceType",
         "location"
       ],
+      "additionalProperties": false,
       "properties": {
         "experienceType": {
           "type": "string",
@@ -307,6 +319,7 @@
         "experienceType",
         "callDetails"
       ],
+      "additionalProperties": false,
       "properties": {
         "experienceType": {
           "type": "string",
@@ -322,6 +335,7 @@
             "time",
             "calledFrom"
           ],
+          "additionalProperties": false,
           "properties": {
             "numberCalled": {
               "type": "string"
@@ -346,6 +360,7 @@
       "required": [
         "experienceType"
       ],
+      "additionalProperties": false,
       "properties": {
         "experienceType": {
           "type": "string",
@@ -359,10 +374,10 @@
       "type": "object",
       "required": [
         "complaintType",
-        "reference",
         "reporterDetails",
         "complaintDetails"
       ],
+      "additionalProperties": false,
       "properties": {
         "complaintType": {
           "type": "string",
@@ -382,6 +397,7 @@
             "complaintText",
             "problemExperienced"
           ],
+          "additionalProperties": false,
           "properties": {
             "complaintText": {
               "$ref": "#/definitions/ComplaintDetailsText"
@@ -405,10 +421,10 @@
       "type": "object",
       "required": [
         "complaintType",
-        "reference",
         "reporterDetails",
         "complaintDetails"
       ],
+      "additionalProperties": false,
       "properties": {
         "complaintType": {
           "type": "string",
@@ -428,6 +444,7 @@
             "complaintText",
             "problemExperienced"
           ],
+          "additionalProperties": false,
           "properties": {
             "complaintText": {
               "$ref": "#/definitions/ComplaintDetailsText"
@@ -449,220 +466,19 @@
         }
       }
     },
-    "BrpComplaint": {
-      "type": "object",
-      "required": [
-        "complaintType",
-        "reference",
-        "reporterDetails",
-        "complaintDetails"
-      ],
-      "properties": {
-        "complaintType": {
-          "type": "string",
-          "enum": [
-            "BIOMETRIC_RESIDENCE_PERMIT"
-          ]
-        },
-        "reference": {
-          "$ref": "#/definitions/Reference"
-        },
-        "reporterDetails": {
-          "$ref": "#/definitions/ReporterDetails"
-        },
-        "complaintDetails": {
-          "type": "object",
-          "required": [
-            "complaintText",
-            "problemExperienced"
-          ],
-          "properties": {
-            "complaintText": {
-              "$ref": "#/definitions/ComplaintDetailsText"
-            },
-            "problemExperienced": {
-              "type": "string",
-              "enum": [
-                "CARD_NOT_ARRIVED",
-                "CARD_INCORRECT",
-                "COMPLAIN_BRP"
-              ]
-            }
-          }
-        }
-      }
-    },
-    "InformationIssueComplaint": {
-      "type": "object",
-      "required": [
-        "complaintType",
-        "reference",
-        "reporterDetails",
-        "complaintDetails"
-      ],
-      "properties": {
-        "complaintType": {
-          "type": "string",
-          "enum": [
-            "POOR_INFORMATION"
-          ]
-        },
-        "reference": {
-          "$ref": "#/definitions/Reference"
-        },
-        "reporterDetails": {
-          "$ref": "#/definitions/ReporterDetails"
-        },
-        "complaintDetails": {
-          "type": "object",
-          "required": [
-            "complaintText"
-          ],
-          "properties": {
-            "complaintText": {
-              "$ref": "#/definitions/ComplaintDetailsText"
-            }
-          }
-        }
-      }
-    },
-    "StaffBehaviourComplaint": {
-      "type": "object",
-      "required": [
-        "complaintType",
-        "complaintDetails",
-        "reporterDetails"
-      ],
-      "properties": {
-        "complaintType": {
-          "type": "string",
-          "enum": [
-            "POOR_STAFF_BEHAVIOUR"
-          ]
-        },
-        "reporterDetails": {
-          "$ref": "#/definitions/ReporterDetails"
-        },
-        "complaintDetails": {
-          "type": "object",
-          "required": [
-            "complaintText",
-            "experience"
-          ],
-          "properties": {
-            "complaintText": {
-              "$ref": "#/definitions/ComplaintDetailsText"
-            },
-            "experience": {
-              "oneOf": [
-                {
-                  "$ref": "#/definitions/FaceToFaceExperience"
-                },
-                {
-                  "$ref": "#/definitions/PhoneExperience"
-                },
-                {
-                  "$ref": "#/definitions/LetterEmailExperience"
-                }
-              ]
-            }
-          }
-        }
-      }
-    },
-    "ExistingComplaint": {
-      "type": "object",
-      "required": [
-        "complaintType",
-        "complaintDetails",
-        "reporterDetails"
-      ],
-      "properties": {
-        "complaintType": {
-          "type": "string",
-          "enum": [
-            "EXISTING"
-          ]
-        },
-        "complaintDetails": {
-          "type": "object",
-          "required": [
-            "complaintReferenceNumber",
-            "complaintText",
-            "previousComplaintType"
-          ],
-          "properties": {
-            "complaintReferenceNumber": {
-              "type": "string"
-            },
-            "complaintText": {
-              "$ref": "#/definitions/ComplaintDetailsText"
-            },
-            "previousComplaintType": {
-              "$ref": "#/definitions/ComplaintType"
-            }
-          }
-        },
-        "reporterDetails": {
-          "$ref": "#/definitions/ReporterDetails"
-        }
-      }
-    },
-    "SomethingElseComplaint": {
-      "type": "object",
-      "required": [
-        "complaintType",
-        "reference",
-        "reporterDetails",
-        "complaintDetails"
-      ],
-      "properties": {
-        "complaintType": {
-          "type": "string",
-          "enum": [
-            "SOMETHING_ELSE"
-          ]
-        },
-        "reference": {
-          "$ref": "#/definitions/Reference"
-        },
-        "reporterDetails": {
-          "$ref": "#/definitions/ReporterDetails"
-        },
-        "complaintDetails": {
-          "type": "object",
-          "required": [
-            "complaintText"
-          ],
-          "properties": {
-            "complaintText": {
-              "$ref": "#/definitions/ComplaintDetailsText"
-            }
-          }
-        }
-      }
-    },
     "DelaysComplaint": {
       "type": "object",
       "required": [
         "complaintType",
-        "reference",
         "reporterDetails",
         "complaintDetails"
       ],
+      "additionalProperties": false,
       "properties": {
         "complaintType": {
           "type": "string",
           "enum": [
             "DELAYS"
-          ]
-        },
-        "documentReturnRequest": {
-          "type": "string",
-          "enum": [
-            "YES_DOCS_SERVICE",
-            "YES_OTHER",
-            "NO"
           ]
         },
         "reference": {
@@ -677,6 +493,7 @@
             "complaintText",
             "delayedWaitingFor"
           ],
+          "additionalProperties": false,
           "properties": {
             "complaintText": {
               "$ref": "#/definitions/ComplaintDetailsText"
@@ -686,6 +503,14 @@
               "enum": [
                 "APPLICATION_DELAY",
                 "RETURN_OF_DOCUMENTS"
+              ]
+            },
+            "documentReturnRequest": {
+              "type": "string",
+              "enum": [
+                "YES_DOCS_SERVICE",
+                "YES_OTHER",
+                "NO"
               ]
             },
             "applicationSubmittedWhen": {
@@ -702,10 +527,10 @@
       "type": "object",
       "required": [
         "complaintType",
-        "reference",
         "reporterDetails",
         "complaintDetails"
       ],
+      "additionalProperties": false,
       "properties": {
         "complaintType": {
           "type": "string",
@@ -725,6 +550,7 @@
             "complaintText",
             "decisionOutcome"
           ],
+          "additionalProperties": false,
           "properties": {
             "complaintText": {
               "$ref": "#/definitions/ComplaintDetailsText"
@@ -743,14 +569,58 @@
         }
       }
     },
+    "BrpComplaint": {
+      "type": "object",
+      "required": [
+        "complaintType",
+        "reporterDetails",
+        "complaintDetails"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "complaintType": {
+          "type": "string",
+          "enum": [
+            "BIOMETRIC_RESIDENCE_PERMIT"
+          ]
+        },
+        "reference": {
+          "$ref": "#/definitions/Reference"
+        },
+        "reporterDetails": {
+          "$ref": "#/definitions/ReporterDetails"
+        },
+        "complaintDetails": {
+          "type": "object",
+          "required": [
+            "complaintText",
+            "problemExperienced"
+          ],
+          "additionalProperties": false,
+          "properties": {
+            "complaintText": {
+              "$ref": "#/definitions/ComplaintDetailsText"
+            },
+            "problemExperienced": {
+              "type": "string",
+              "enum": [
+                "CARD_NOT_ARRIVED",
+                "CARD_INCORRECT",
+                "COMPLAIN_BRP"
+              ]
+            }
+          }
+        }
+      }
+    },
     "RefundComplaint": {
       "type": "object",
       "required": [
         "complaintType",
-        "reference",
         "reporterDetails",
         "complaintDetails"
       ],
+      "additionalProperties": false,
       "properties": {
         "complaintType": {
           "type": "string",
@@ -770,6 +640,7 @@
             "complaintText",
             "refundRequested"
           ],
+          "additionalProperties": false,
           "properties": {
             "complaintText": {
               "$ref": "#/definitions/ComplaintDetailsText"
@@ -799,6 +670,195 @@
           }
         }
       }
+    },
+    "InformationIssueComplaint": {
+      "type": "object",
+      "required": [
+        "complaintType",
+        "reporterDetails",
+        "complaintDetails"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "complaintType": {
+          "type": "string",
+          "enum": [
+            "POOR_INFORMATION"
+          ]
+        },
+        "reference": {
+          "$ref": "#/definitions/Reference"
+        },
+        "reporterDetails": {
+          "$ref": "#/definitions/ReporterDetails"
+        },
+        "complaintDetails": {
+          "type": "object",
+          "required": [
+            "complaintText"
+          ],
+          "additionalProperties": false,
+          "properties": {
+            "complaintText": {
+              "$ref": "#/definitions/ComplaintDetailsText"
+            }
+          }
+        }
+      }
+    },
+    "StaffBehaviourComplaint": {
+      "type": "object",
+      "required": [
+        "complaintType",
+        "reporterDetails",
+        "complaintDetails"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "complaintType": {
+          "type": "string",
+          "enum": [
+            "POOR_STAFF_BEHAVIOUR"
+          ]
+        },
+        "reference": {
+          "$ref": "#/definitions/Reference"
+        },
+        "reporterDetails": {
+          "$ref": "#/definitions/ReporterDetails"
+        },
+        "complaintDetails": {
+          "type": "object",
+          "required": [
+            "complaintText",
+            "experience"
+          ],
+          "additionalProperties": false,
+          "properties": {
+            "complaintText": {
+              "$ref": "#/definitions/ComplaintDetailsText"
+            },
+            "experience": {
+              "oneOf": [
+                {
+                  "$ref": "#/definitions/FaceToFaceExperience"
+                },
+                {
+                  "$ref": "#/definitions/PhoneExperience"
+                },
+                {
+                  "$ref": "#/definitions/LetterEmailExperience"
+                }
+              ]
+            }
+          }
+        }
+      }
+    },
+    "NoRefPreviousComplaint": {
+      "type": "object",
+      "required": [
+        "previousComplaintType"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "previousComplaintType": {
+          "$ref": "#/definitions/ComplaintType"
+        }
+      }
+    },
+    "HasRefPreviousComplaint": {
+      "type": "object",
+      "required": [
+        "complaintReferenceNumber",
+        "complaintText"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "complaintReferenceNumber": {
+          "type": "string"
+        },
+        "complaintText": {
+          "$ref": "#/definitions/ComplaintDetailsText"
+        }
+      }
+    },
+    "PreviousComplaint": {
+      "oneOf": [
+        {
+          "$ref": "#/definitions/HasRefPreviousComplaint"
+        },
+        {
+          "$ref": "#/definitions/NoRefPreviousComplaint"
+        }
+      ]
+    },
+    "ExistingComplaint": {
+      "type": "object",
+      "required": [
+        "complaintType",
+        "complaintDetails"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "complaintType": {
+          "type": "string",
+          "enum": [
+            "EXISTING"
+          ]
+        },
+        "reporterDetails": {
+          "$ref": "#/definitions/ReporterDetails"
+        },
+        "complaintDetails": {
+          "type": "object",
+          "required": [
+            "previousComplaint"
+          ],
+          "additionalProperties": false,
+          "properties": {
+            "previousComplaint": {
+              "$ref": "#/definitions/PreviousComplaint"
+            }
+          }
+        }
+      }
+    },
+    "SomethingElseComplaint": {
+      "type": "object",
+      "required": [
+        "complaintType",
+        "reference",
+        "reporterDetails",
+        "complaintDetails"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "complaintType": {
+          "type": "string",
+          "enum": [
+            "SOMETHING_ELSE"
+          ]
+        },
+        "reference": {
+          "$ref": "#/definitions/Reference"
+        },
+        "reporterDetails": {
+          "$ref": "#/definitions/ReporterDetails"
+        },
+        "complaintDetails": {
+          "type": "object",
+          "required": [
+            "complaintText"
+          ],
+          "additionalProperties": false,
+          "properties": {
+            "complaintText": {
+              "$ref": "#/definitions/ComplaintDetailsText"
+            }
+          }
+        }
+      }
     }
   },
   "type": "object",
@@ -806,6 +866,7 @@
     "creationDate",
     "complaint"
   ],
+  "additionalProperties": false,
   "properties": {
     "creationDate": {
       "type": "string",

--- a/src/main/resources/cmsSchema.json
+++ b/src/main/resources/cmsSchema.json
@@ -284,6 +284,48 @@
         "SOMETHING_ELSE"
       ]
     },
+    "PreviousComplaintType": {
+      "oneOf": [
+        {
+          "$ref": "#/definitions/HasRefPreviousComplaintType"
+        },
+        {
+          "$ref": "#/definitions/NoRefPreviousComplaintType"
+        }
+      ]
+    },
+    "NoRefPreviousComplaintType": {
+      "type": "object",
+      "required": [
+        "previousComplaintType",
+        "complaintText"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "previousComplaintType": {
+          "$ref": "#/definitions/ComplaintType"
+        },
+        "complaintText": {
+          "$ref": "#/definitions/ComplaintDetailsText"
+        }
+      }
+    },
+    "HasRefPreviousComplaintType": {
+      "type": "object",
+      "required": [
+        "complaintReferenceNumber",
+        "complaintText"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "complaintReferenceNumber": {
+          "type": "string"
+        },
+        "complaintText": {
+          "$ref": "#/definitions/ComplaintDetailsText"
+        }
+      }
+    },
     "FaceToFaceExperience": {
       "type": "object",
       "required": [
@@ -755,48 +797,6 @@
         }
       }
     },
-    "NoRefPreviousComplaint": {
-      "type": "object",
-      "required": [
-        "previousComplaintType",
-        "complaintText"
-      ],
-      "additionalProperties": false,
-      "properties": {
-        "previousComplaintType": {
-          "$ref": "#/definitions/ComplaintType"
-        },
-        "complaintText": {
-          "$ref": "#/definitions/ComplaintDetailsText"
-        }
-      }
-    },
-    "HasRefPreviousComplaint": {
-      "type": "object",
-      "required": [
-        "complaintReferenceNumber",
-        "complaintText"
-      ],
-      "additionalProperties": false,
-      "properties": {
-        "complaintReferenceNumber": {
-          "type": "string"
-        },
-        "complaintText": {
-          "$ref": "#/definitions/ComplaintDetailsText"
-        }
-      }
-    },
-    "PreviousComplaint": {
-      "oneOf": [
-        {
-          "$ref": "#/definitions/HasRefPreviousComplaint"
-        },
-        {
-          "$ref": "#/definitions/NoRefPreviousComplaint"
-        }
-      ]
-    },
     "ExistingComplaint": {
       "type": "object",
       "required": [
@@ -822,7 +822,7 @@
           "additionalProperties": false,
           "properties": {
             "previousComplaint": {
-              "$ref": "#/definitions/PreviousComplaint"
+              "$ref": "#/definitions/PreviousComplaintType"
             }
           }
         }

--- a/src/main/resources/cmsSchema.json
+++ b/src/main/resources/cmsSchema.json
@@ -758,12 +758,16 @@
     "NoRefPreviousComplaint": {
       "type": "object",
       "required": [
-        "previousComplaintType"
+        "previousComplaintType",
+        "complaintText"
       ],
       "additionalProperties": false,
       "properties": {
         "previousComplaintType": {
           "$ref": "#/definitions/ComplaintType"
+        },
+        "complaintText": {
+          "$ref": "#/definitions/ComplaintDetailsText"
         }
       }
     },

--- a/src/test/java/uk/gov/digital/ho/hocs/correspondence/JSONValidate.java
+++ b/src/test/java/uk/gov/digital/ho/hocs/correspondence/JSONValidate.java
@@ -33,6 +33,16 @@ public class JSONValidate {
     }
 
     @Test
+    public void existingOther() throws Exception {
+        try (
+                InputStream schemaStream = inputStreamFromClasspath("cmsSchema.json");
+                InputStream jsonStream = inputStreamFromClasspath("jsonComplaintExamples/existingOther.json")
+        ) {
+            testSchema(schemaStream, jsonStream);
+        }
+    }
+
+    @Test
     public void makingAppointment() throws Exception {
         try (
                 InputStream schemaStream = inputStreamFromClasspath("cmsSchema.json");

--- a/src/test/resources/jsonComplaintExamples/decision.json
+++ b/src/test/resources/jsonComplaintExamples/decision.json
@@ -15,9 +15,9 @@
       "applicantPhone": "aliqua ea"
     },
     "complaintDetails": {
-      "complaintText": "Ut velit ut magna aliquip"
-    },
-    "decisionOutcome": "POSITIVE",
-    "applicationLocation": "INSIDE_UK"
+      "complaintText": "Ut velit ut magna aliquip",
+      "decisionOutcome": "POSITIVE",
+      "applicationLocation": "INSIDE_UK"
+    }
   }
 }

--- a/src/test/resources/jsonComplaintExamples/delays.json
+++ b/src/test/resources/jsonComplaintExamples/delays.json
@@ -15,10 +15,10 @@
       "applicantPhone": "aliqua ea"
     },
     "complaintDetails": {
-      "complaintText": "pariatur Excepteur laborum dolore"
-    },
-    "delayedWaitingFor": "APPLICATION_DELAY",
-    "applicationSubmittedWhen": "Lorem",
-    "applicationLocation": "INSIDE_UK"
+      "complaintText": "pariatur Excepteur laborum dolore",
+      "delayedWaitingFor": "APPLICATION_DELAY",
+      "applicationSubmittedWhen": "Lorem",
+      "applicationLocation": "INSIDE_UK"
+    }
   }
 }

--- a/src/test/resources/jsonComplaintExamples/existing.json
+++ b/src/test/resources/jsonComplaintExamples/existing.json
@@ -2,11 +2,6 @@
   "creationDate": "1948-08-23",
   "complaint": {
     "complaintType": "EXISTING",
-    "complaintDetails": {
-      "complaintReferenceNumber": "et",
-      "complaintText": "aliquip deserunt eu aute ad",
-      "previousComplaintType": "MAKING_APPOINTMENT"
-    },
     "reporterDetails": {
       "applicantType": "APPLICANT",
       "applicantName": "deserunt",
@@ -14,6 +9,11 @@
       "applicantDob": "2020-10-03",
       "applicantEmail": "sss@uevptde.com",
       "applicantPhone": "01772 700806"
+    },
+    "complaintDetails": {
+      "complaintReferenceNumber": "et",
+      "complaintText": "aliquip deserunt eu aute ad",
+      "previousComplaintType": "MAKING_APPOINTMENT"
     }
   }
 }

--- a/src/test/resources/jsonComplaintExamples/existing.json
+++ b/src/test/resources/jsonComplaintExamples/existing.json
@@ -11,9 +11,10 @@
       "applicantPhone": "01772 700806"
     },
     "complaintDetails": {
-      "complaintReferenceNumber": "et",
-      "complaintText": "aliquip deserunt eu aute ad",
-      "previousComplaintType": "MAKING_APPOINTMENT"
+      "previousComplaint": {
+        "complaintReferenceNumber": "id",
+        "complaintText": "occaecat proident labore dolor sunt"
+      }
     }
   }
 }

--- a/src/test/resources/jsonComplaintExamples/existingOther.json
+++ b/src/test/resources/jsonComplaintExamples/existingOther.json
@@ -1,0 +1,11 @@
+{
+  "creationDate": "1948-08-23",
+  "complaint": {
+    "complaintType": "EXISTING",
+    "complaintDetails": {
+      "previousComplaint": {
+        "previousComplaintType": "IMMIGRATION_DECISION"
+      }
+    }
+  }
+}

--- a/src/test/resources/jsonComplaintExamples/existingOther.json
+++ b/src/test/resources/jsonComplaintExamples/existingOther.json
@@ -4,7 +4,8 @@
     "complaintType": "EXISTING",
     "complaintDetails": {
       "previousComplaint": {
-        "previousComplaintType": "IMMIGRATION_DECISION"
+        "previousComplaintType": "IMMIGRATION_DECISION",
+        "complaintText": "occaecat proident labore dolor sunt"
       }
     }
   }

--- a/src/test/resources/jsonComplaintExamples/poorInformation.json
+++ b/src/test/resources/jsonComplaintExamples/poorInformation.json
@@ -15,7 +15,6 @@
       "applicantPhone": "01772 700806"
     },
     "complaintDetails": {
-      "reason": "BIOMETRIC_RESIDENCE_PERMIT",
       "complaintText": "do tempor"
     }
   }

--- a/src/test/resources/jsonComplaintExamples/refund.json
+++ b/src/test/resources/jsonComplaintExamples/refund.json
@@ -20,10 +20,10 @@
       }
     },
     "complaintDetails": {
-      "complaintText": "in ex ut ipsum dolor"
-    },
-    "refundRequested": "YES",
-    "applicationLocation": "INSIDE_UK",
-    "refundType": "STANDARD"
+      "complaintText": "in ex ut ipsum dolor",
+      "refundRequested": "YES",
+      "applicationLocation": "INSIDE_UK",
+      "refundType": "STANDARD"
+    }
   }
 }

--- a/src/test/resources/jsonComplaintExamples/staffBehaviour.json
+++ b/src/test/resources/jsonComplaintExamples/staffBehaviour.json
@@ -7,18 +7,26 @@
       "reference": "amet"
     },
     "reporterDetails": {
-      "applicantType": "APPLICANT",
-      "applicantName": "dolor ad eiusmod aute",
-      "applicantNationality": "Guinea",
-      "applicantDob": "2020-10-03",
-      "applicantEmail": "sss@uevptde.co.uk",
-      "applicantPhone": "01772 700806"
+      "applicantType": "AGENT",
+      "applicantDetails": {
+        "applicantName": "sint enim incididunt in",
+        "applicantNationality": "Lorem",
+        "applicantDob": "1989-08-23"
+      },
+      "agentDetails": {
+        "agentName": "id",
+        "agentType": "RELATIVE",
+        "agentEmail": "cupidatat in"
+      }
     },
     "complaintDetails": {
-      "reason": "UNCLEAR_MISLEADING_INFORMATION",
-      "complaintText": "mollit deserunt",
+      "complaintText": "officia laborum dolore",
       "experience": {
-        "experienceType": "LETTER_OR_EMAIL"
+        "experienceType": "FACE_TO_FACE",
+        "location": {
+          "country": "dolore consequat",
+          "city": "sit aute incididunt mollit"
+        }
       }
     }
   }

--- a/src/test/resources/jsonComplaintExamples/staffBehaviour.json
+++ b/src/test/resources/jsonComplaintExamples/staffBehaviour.json
@@ -2,23 +2,23 @@
   "creationDate": "2020-10-03",
   "complaint": {
     "complaintType": "POOR_STAFF_BEHAVIOUR",
-    "experience": {
-      "experienceType": "LETTER_OR_EMAIL",
-      "reference": {
-        "referenceType": "IHS_REF",
-        "reference": "amet"
-      },
-      "reporterDetails": {
-        "applicantType": "APPLICANT",
-        "applicantName": "dolor ad eiusmod aute",
-        "applicantNationality": "Guinea",
-        "applicantDob": "2020-10-03",
-        "applicantEmail": "sss@uevptde.co.uk",
-        "applicantPhone": "01772 700806"
-      },
-      "complaintDetails": {
-        "reason": "UNCLEAR_MISLEADING_INFORMATION",
-        "complaintText": "mollit deserunt"
+    "reference": {
+      "referenceType": "IHS_REF",
+      "reference": "amet"
+    },
+    "reporterDetails": {
+      "applicantType": "APPLICANT",
+      "applicantName": "dolor ad eiusmod aute",
+      "applicantNationality": "Guinea",
+      "applicantDob": "2020-10-03",
+      "applicantEmail": "sss@uevptde.co.uk",
+      "applicantPhone": "01772 700806"
+    },
+    "complaintDetails": {
+      "reason": "UNCLEAR_MISLEADING_INFORMATION",
+      "complaintText": "mollit deserunt",
+      "experience": {
+        "experienceType": "LETTER_OR_EMAIL"
       }
     }
   }

--- a/src/test/resources/jsonComplaintExamples/submittingApplication.json
+++ b/src/test/resources/jsonComplaintExamples/submittingApplication.json
@@ -16,8 +16,8 @@
     },
     "complaintDetails": {
       "complaintText": "ut qui eiusmod",
-      "problemExperienced": "SOMETHING_ELSE"
-    },
-    "applicationLocation": "OUTSIDE_UK"
+      "problemExperienced": "SOMETHING_ELSE",
+      "applicationLocation": "OUTSIDE_UK"
+    }
   }
 }


### PR DESCRIPTION
I've re-ordered some of the complaint types so that they all follow the same structure.

  "creationDate"
  "complaint"
      "complaintType"
      "reference"
      "reporterDetails"
      "complaintDetails"

complaintDetails varies by complaint type.
Hopefully this way we can use the JSON to simplify the creation code.
