### PR TITLE
SD-272: Update schema to remove date format from phone experience

### DIFF
--- a/src/main/resources/cmsSchema.json
+++ b/src/main/resources/cmsSchema.json
@@ -396,7 +396,7 @@
             },
             "date": {
               "type": "string",
-              "format": "date"
+              "description": "30 April or early June"
             },
             "time": {
               "type": "string",


### PR DESCRIPTION
### What
Removes 'date' format constraint from date field in phone experience complaint type
Adds description to give context
### Why
On the HOF form the field allows strings e.g '30 April or early June'