### PR TITLE
Add various GitHub functions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,28 @@
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "daily"
+    commit-message:
+      prefix: "⬆️ "
+    pull-request-branch-name:
+      separator: "-"
+    reviewers:
+      - "UKHomeOffice/hocs-core"
+    labels:
+      - "skip-release"
+      - "dependencies"
+  - package-ecosystem: "gradle"
+    directory: "/"
+    schedule:
+      interval: "daily"
+    commit-message:
+      prefix: "⬆️ "
+    pull-request-branch-name:
+      separator: "-"
+    reviewers:
+      - "UKHomeOffice/hocs-core"
+    labels:
+      - "skip-release"
+      - "dependencies"

--- a/.github/workflows/pr-check.yml
+++ b/.github/workflows/pr-check.yml
@@ -1,0 +1,22 @@
+name: 'PR Checker'
+on:
+  pull_request:
+    types: [ labeled, unlabeled, opened, reopened, synchronize ]
+
+jobs:
+  build:
+    name: PR Checker
+    runs-on: ubuntu-latest
+    steps:
+      - id: label
+        uses: UKHomeOffice/match-label-action@v1
+        with:
+          labels: minor,major,patch,skip-release
+          mode: singular
+      - uses: UKHomeOffice/semver-tag-action@v2
+        if: contains(steps.label.outputs.matchedLabels, 'skip-release') == false
+        with:
+          increment: ${{ steps.label.outputs.matchedLabels }}
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          default_use_head_tag: ${{ github.base_ref == 'main' }}
+          dry_run: true

--- a/.github/workflows/semver.yml
+++ b/.github/workflows/semver.yml
@@ -1,0 +1,31 @@
+name: 'SemVer tag the commit'
+on:
+  pull_request:
+    types: [ closed ]
+
+jobs:
+  build:
+    name: SemVer tag the commit
+    runs-on: ubuntu-latest
+    if: github.event.pull_request.merged == true
+    steps:
+      - id: label
+        uses: UKHomeOffice/match-label-action@v1
+        with:
+          labels: minor,major,patch,skip-release
+          mode: singular
+      - uses: UKHomeOffice/semver-tag-action@v2
+        if: contains(steps.label.outputs.matchedLabels, 'skip-release') == false
+        with:
+          increment: ${{ steps.label.outputs.matchedLabels }}
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          default_use_head_tag: ${{ github.base_ref == 'main' }}
+      - name: Post failure to Slack channel
+        id: slack
+        uses: slackapi/slack-github-action@v1.19.0
+        if: ${{ failure() && steps.*.conclusion == 'failure' }}
+        with:
+          channel-id: ${{ secrets.SLACK_CHANNEL_ID }}
+          slack-message: "GitHub Action failure: ${{github.repository}}\nRun: ${{github.server_url}}/${{github.repository}}/actions/runs/${{github.run_id}}\nOriginating PR: ${{ github.event.pull_request.html_url || github.event.head_commit.url }}"
+        env:
+          SLACK_BOT_TOKEN: ${{ secrets.SLACK_BOT_TOKEN }}

--- a/build.gradle
+++ b/build.gradle
@@ -19,9 +19,9 @@ sourceCompatibility = '11'
 targetCompatibility = '11'
 
 dependencies {
-    compile 'junit:junit:4.12'
-    compile 'com.networknt:json-schema-validator:1.0.49'
-    implementation 'com.jayway.jsonpath:json-path:2.5.0'
+    testImplementation 'junit:junit:4.12'
+    testImplementation 'com.networknt:json-schema-validator:1.0.49'
+    testImplementation 'com.jayway.jsonpath:json-path:2.5.0'
 }
 
 publishing {
@@ -44,4 +44,3 @@ publishing {
         }
     }
 }
-


### PR DESCRIPTION
Bring the project in line to use the SemVer tagging actions that has
become the standard in the HOCS services.

Add dependabot configuration that support updates to Gradle Dependencies
and GitHub Actions. As the dependencies this uses are purely for
testing purposes these have been altered within the build.gradle file.
This also changes the gradle dependencies to be a skip-release as they
don't impact the final package.