### PR TITLE
Change dependency to implementation

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -18,8 +18,9 @@ sourceCompatibility = JavaVersion.VERSION_17
 targetCompatibility = JavaVersion.VERSION_17
 
 dependencies {
+    implementation 'com.networknt:json-schema-validator:1.0.70'
+
     testImplementation 'junit:junit:4.13.2'
-    testImplementation 'com.networknt:json-schema-validator:1.0.70'
     testImplementation 'com.jayway.jsonpath:json-path:2.7.0'
 }
 


### PR DESCRIPTION
Change the JSON validator dependency to `Implementation` so that it is
packaged with the final artifact. This allows the ingesting service to
use the same version of the validator.