### PR TITLE
HOCS-5180: remove Artifactory publish

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ This is a [useful site for generating JSON from JSON schema](https://json-schema
 
 ## Publishing
 
-When the repository is tagged this schema is currently published to both Artifactory and GitHub Packages.
+When the repository is tagged this schema is currently published to GitHub Packages.
 
 View the `.drone.yml` file for more information on the commands used in the pipeline and when this is triggered.
 

--- a/build.gradle
+++ b/build.gradle
@@ -33,15 +33,6 @@ publishing {
 
     repositories {
         maven {
-            name = 'hocs-ukvi-complaint-schema'
-            description = 'The JSON schema for the UKVI Complaints Management complaint schema'
-            url = 'https://artifactory.digital.homeoffice.gov.uk/artifactory/DECS/'
-            credentials {
-                username = System.getenv('ARTIFACTORY_USER')
-                password = System.getenv('ARTIFACTORY_TOKEN')
-            }
-        }
-        maven {
             name = "hocs-ukvi-complaint-schema"
             description = 'The JSON schema for the UKVI Complaints Management complaint schema'
             url = 'https://maven.pkg.github.com/UKHomeOffice/hocs-ukvi-complaint-schema'


### PR DESCRIPTION
As we are now using GitHub Packages - this change removes the publishing
to the private Artifactory instance.